### PR TITLE
psplash: Make sure that double buffering is disabled.

### DIFF
--- a/recipes-core/psplash/psplash_git.bbappend
+++ b/recipes-core/psplash/psplash_git.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend_sawfish := "${THISDIR}/${PN}:"
-SRC_URI_append_sawfish += " file://0001-Disable-double-buffering.patch"
+FILESEXTRAPATHS_prepend_skipjack := "${THISDIR}/${PN}:"
+SRC_URI_append_skipjack += " file://0001-Disable-double-buffering.patch"
 
 SPLASH_IMAGES = "file://psplash-img-280.png;outsuffix=default"


### PR DESCRIPTION
A typo caused the patch to be applied to sawfish only instead of skipjack.